### PR TITLE
Chainlink import fix

### DIFF
--- a/Build Hogwarts Sorting Cap dApp on the Polygon Mumbai/2. Build Hogwarts Contract/2. Create House Assignment Contract.md
+++ b/Build Hogwarts Sorting Cap dApp on the Polygon Mumbai/2. Build Hogwarts Contract/2. Create House Assignment Contract.md
@@ -22,7 +22,7 @@ pragma solidity ^0.8.8;
 ```
 import "./HogwartsNFT.sol";
 import "@chainlink/contracts/src/v0.8/interfaces/VRFCoordinatorV2Interface.sol";
-import "@chainlink/contracts/src/v0.8/VRFConsumerBaseV2.sol"
+import "@chainlink/contracts/src/v0.8/vrf/VRFConsumerBaseV2.sol"
 ```
 
 - These lines import external contracts and interfaces:


### PR DESCRIPTION
Added the correct path for the "VRFConsumerBaseV2.sol" import from @chainlink.